### PR TITLE
Updates to align with wolfHSM.  Depends on wolfHSM PR#19

### DIFF
--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -77,10 +77,10 @@ SRC_C += \
             $(WOLFHSM_DIR)/src/wh_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_message_customcb.c \
+            $(WOLFHSM_DIR)/src/wh_message_customcb.c
 
 # WolfHSM port\HAL code
-SRC_C += $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c \
+SRC_C += $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c
 
 # APP
 SRC_C += ./src/wh_client_tcp.c 

--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -50,14 +50,37 @@ LDFLAGS += $(DBGFLAGS)
 # Assembly source files
 SRC_ASM += 
 
-# WolfHSM source code
+#wolfCrypt source files
+SRC_C += \
+            $(WOLFSSL_DIR)/wolfcrypt/src/wc_port.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/memory.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/misc.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/cryptocb.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/random.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/asn.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/coding.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/wolfmath.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/tfm.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/fe_operations.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/rsa.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/curve25519.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/hash.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/sha256.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/aes.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/cmac.c
+
+# wolfHSM source files
 SRC_C += \
             $(WOLFHSM_DIR)/src/wh_client.c \
+            $(WOLFHSM_DIR)/src/wh_client_nvm.c \
+            $(WOLFHSM_DIR)/src/wh_client_cryptocb.c \
             $(WOLFHSM_DIR)/src/wh_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_comm.c \
+            $(WOLFHSM_DIR)/src/wh_message_nvm.c \
+            $(WOLFHSM_DIR)/src/wh_message_customcb.c \
 
-# WolfHSM port code
-SRC_C += $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c
+# WolfHSM port\HAL code
+SRC_C += $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c \
 
 # APP
 SRC_C += ./src/wh_client_tcp.c 

--- a/posix/tcp/wh_client_tcp/user_settings.h
+++ b/posix/tcp/wh_client_tcp/user_settings.h
@@ -2,9 +2,111 @@
 
 /* Client wolfSSL settings */
 
-#define WOLFSSL_CRYPTO_CB
+/* Common configuration */
+#define WOLFCRYPT_ONLY
+//#define BIG_ENDIAN_ORDER
+#define WOLF_CRYPTO_CB
+//#define WOLFSSL_KEY_GEN
+#define SINGLE_THREADED
+#define WC_NO_ASYNC_THREADING
+#define WOLFSSL_USE_ALIGN
+#define HAVE_WC_INTROSPECTION
+#define WOLFSSL_IGNORE_FILE_WARN
 
-/* Client wolfHSM settings */
-#define HAVE_WOLFHSM_CLIENT
+#define WOLFSSL_NO_MALLOC
+
+/* Hardening options */
+#define TFM_TIMING_RESISTANT
+#define ECC_TIMING_RESISTANT
+#define WC_RSA_BLINDING
+
+/* Remove unneeded features*/
+#define NO_MAIN_DRIVER
+#define NO_ERROR_STRINGS
+#define NO_ERROR_QUEUE
+#define NO_FILESYSTEM
+#define NO_INLINE
+#define NO_OLD_TLS
+#define WOLFSSL_NO_TLS12
+#define NO_DO178
+
+/* Remove unneded namespace */
+#define NO_OLD_RNGNAME
+#define NO_OLD_WC_NAMES
+#define NO_OLD_SSL_NAMES
+#define NO_OLD_SHA_NAMES
+#define NO_OLD_MD5_NAME
+
+/* RSA Options */
+//#define NO_RSA
+#define HAVE_RSA
+#define WC_RSA_PSS
+#define WOLFSSL_PSS_LONG_SALT
+#define FP_MAX_BITS 4096
+
+/* ECC Options */
+//#define HAVE_ECC
+#define NO_ECC
+#define TFM_ECC256
+#define ECC_SHAMIR
+#define HAVE_SUPPORTED_CURVES
+
+/* Curve25519 Options */
+#define HAVE_CURVE25519
+
+/* DH and DHE Options */
+#define HAVE_DH_DEFAULT_PARAMS
+#define HAVE_FFDHE_2048
+
+/* AES Options */
+#define HAVE_AES
+#define HAVE_AESGCM
+#define GCM_TABLE_4BIT
+#define WOLFSSL_AES_DIRECT
+#define HAVE_AES_ECB
+#define WOLFSSL_CMAC
+
+/* SHA Options */
+#define NO_SHA
+#define HAVE_SHA256
+
+/* Composite features */
+#define HAVE_HKDF
+#define HAVE_HASHDRBG
+
+/* Remove unneeded crypto */
+#define NO_DSA
+#define NO_RC4
+#define NO_PSK
+#define NO_MD4
+#define NO_MD5
+#define NO_DES3
+#define WOLFSSL_NO_SHAKE128
+#define WOLFSSL_NO_SHAKE256
+#define NO_PWDBASED
+
+/* Disable DH for now */
+#define NO_DH
+
+/* Cert processing options */
+#define WOLFSSL_ASN_TEMPLATE
+#define WOLFSSL_BASE64_ENCODE
+
+/* TLS features that are not used */
+/* TODO: Check to see if these can be removed */
+#define HAVE_TLS_EXTENSIONS
+#define HAVE_ENCRYPT_THEN_MAC
+
+/* Math library selection. Move to target */
+
+#define USE_FAST_MATH
+
+
+/* Curve25519 Options */
+#define HAVE_CURVE25519
+
+/* Math library selection.  Update makefile list if changed */
+#define USE_FAST_MATH
+
 
 #endif

--- a/posix/tcp/wh_client_tcp/wh_client_tcp.c
+++ b/posix/tcp/wh_client_tcp/wh_client_tcp.c
@@ -46,7 +46,7 @@ static void* wh_ClientTask(void* cf)
 {
     whClientConfig* config = (whClientConfig*)cf;
     int ret = 0;
-    whClient client[1];
+    whClientContext client[1];
     int counter = 1;
 
 

--- a/posix/tcp/wh_server_tcp/Makefile
+++ b/posix/tcp/wh_server_tcp/Makefile
@@ -50,14 +50,43 @@ LDFLAGS += $(DBGFLAGS)
 # Assembly source files
 SRC_ASM += 
 
-# WolfHSM source code
+# wolfCrypt source files
+SRC_C += \
+            $(WOLFSSL_DIR)/wolfcrypt/src/wc_port.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/memory.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/misc.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/cryptocb.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/random.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/asn.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/coding.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/wolfmath.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/tfm.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/fe_operations.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/rsa.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/curve25519.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/hash.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/sha256.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/aes.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/cmac.c \
+
+# WolfHSM source files
 SRC_C += \
             $(WOLFHSM_DIR)/src/wh_server.c \
+            $(WOLFHSM_DIR)/src/wh_server_customcb.c \
+            $(WOLFHSM_DIR)/src/wh_server_nvm.c \
+            $(WOLFHSM_DIR)/src/wh_server_crypto.c \
+            $(WOLFHSM_DIR)/src/wh_nvm.c \
             $(WOLFHSM_DIR)/src/wh_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_comm.c \
+            $(WOLFHSM_DIR)/src/wh_message_nvm.c \
+            $(WOLFHSM_DIR)/src/wh_message_customcb.c \
 
-# WolfHSM port code
-SRC_C += $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c
+# WolfHSM port\HAL code
+SRC_C += \
+            $(WOLFHSM_DIR)/src/wh_nvm_flash.c \
+            $(WOLFHSM_DIR)/src/wh_flash_unit.c \
+            $(WOLFHSM_DIR)/src/wh_flash_ramsim.c \
+            $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c \
 
 # APP
 SRC_C += ./src/wh_server_tcp.c 

--- a/posix/tcp/wh_server_tcp/Makefile
+++ b/posix/tcp/wh_server_tcp/Makefile
@@ -67,7 +67,7 @@ SRC_C += \
             $(WOLFSSL_DIR)/wolfcrypt/src/hash.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/sha256.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/aes.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/cmac.c \
+            $(WOLFSSL_DIR)/wolfcrypt/src/cmac.c
 
 # WolfHSM source files
 SRC_C += \
@@ -75,18 +75,19 @@ SRC_C += \
             $(WOLFHSM_DIR)/src/wh_server_customcb.c \
             $(WOLFHSM_DIR)/src/wh_server_nvm.c \
             $(WOLFHSM_DIR)/src/wh_server_crypto.c \
+            $(WOLFHSM_DIR)/src/wh_server_keystore.c \
             $(WOLFHSM_DIR)/src/wh_nvm.c \
             $(WOLFHSM_DIR)/src/wh_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_message_customcb.c \
+            $(WOLFHSM_DIR)/src/wh_message_customcb.c
 
 # WolfHSM port\HAL code
 SRC_C += \
             $(WOLFHSM_DIR)/src/wh_nvm_flash.c \
             $(WOLFHSM_DIR)/src/wh_flash_unit.c \
             $(WOLFHSM_DIR)/src/wh_flash_ramsim.c \
-            $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c \
+            $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c
 
 # APP
 SRC_C += ./src/wh_server_tcp.c 

--- a/posix/tcp/wh_server_tcp/user_settings.h
+++ b/posix/tcp/wh_server_tcp/user_settings.h
@@ -1,10 +1,107 @@
 #ifndef USER_SETTINGS_H
+#define USER_SETTINGS_H
 /* Server wolfSSL settings */
 
-#define WOLFSSL_CRYPTO_CB
+/* Common configuration */
+#define WOLFCRYPT_ONLY
+//#define BIG_ENDIAN_ORDER
+#define WOLF_CRYPTO_CB
+//#define WOLFSSL_KEY_GEN
+#define SINGLE_THREADED
+#define WC_NO_ASYNC_THREADING
+#define WOLFSSL_USE_ALIGN
+#define HAVE_WC_INTROSPECTION
+#define WOLFSSL_IGNORE_FILE_WARN
+
+#define WOLFSSL_NO_MALLOC
+
+/* Hardening options */
+#define TFM_TIMING_RESISTANT
+#define ECC_TIMING_RESISTANT
+#define WC_RSA_BLINDING
+
+/* Remove unneeded features*/
+#define NO_MAIN_DRIVER
+#define NO_ERROR_STRINGS
+#define NO_ERROR_QUEUE
+#define NO_FILESYSTEM
+#define NO_INLINE
+#define NO_OLD_TLS
+#define WOLFSSL_NO_TLS12
+#define NO_DO178
+
+/* Remove unneded namespace */
+#define NO_OLD_RNGNAME
+#define NO_OLD_WC_NAMES
+#define NO_OLD_SSL_NAMES
+#define NO_OLD_SHA_NAMES
+#define NO_OLD_MD5_NAME
+
+/* RSA Options */
+//#define NO_RSA
+#define HAVE_RSA
+#define WC_RSA_PSS
+#define WOLFSSL_PSS_LONG_SALT
+#define FP_MAX_BITS 4096
+
+/* ECC Options */
+//#define HAVE_ECC
+#define NO_ECC
+#define TFM_ECC256
+#define ECC_SHAMIR
+#define HAVE_SUPPORTED_CURVES
+
+/* Curve25519 Options */
+#define HAVE_CURVE25519
+
+/* DH and DHE Options */
+#define HAVE_DH_DEFAULT_PARAMS
+#define HAVE_FFDHE_2048
+
+/* AES Options */
+#define HAVE_AES
+#define HAVE_AESGCM
+#define GCM_TABLE_4BIT
+#define WOLFSSL_AES_DIRECT
+#define HAVE_AES_ECB
+#define WOLFSSL_CMAC
+
+/* SHA Options */
+#define NO_SHA
+#define HAVE_SHA256
+
+/* Composite features */
+#define HAVE_HKDF
+#define HAVE_HASHDRBG
+
+/* Remove unneeded crypto */
+#define NO_DSA
+#define NO_RC4
+#define NO_PSK
+#define NO_MD4
+#define NO_MD5
+#define NO_DES3
+#define WOLFSSL_NO_SHAKE128
+#define WOLFSSL_NO_SHAKE256
+#define NO_PWDBASED
+
+/* Disable DH for now */
+#define NO_DH
+
+/* Cert processing options */
+#define WOLFSSL_ASN_TEMPLATE
+#define WOLFSSL_BASE64_ENCODE
+
+/* TLS features that are not used */
+/* TODO: Check to see if these can be removed */
+#define HAVE_TLS_EXTENSIONS
+#define HAVE_ENCRYPT_THEN_MAC
+
+/* Math library selection. Move to target */
+
+#define USE_FAST_MATH
 
 
-/* Server wolfHSM settings */
-#define HAVE_WOLFHSM_SERVER
 
-#define USER_SETTINGS_H
+#endif  /*define USER_SETTINGS_H */
+

--- a/posix/tcp/wh_server_tcp/wh_server_tcp.c
+++ b/posix/tcp/wh_server_tcp/wh_server_tcp.c
@@ -43,7 +43,7 @@ static void* wh_ServerTask(void* cf)
 {
     whServerConfig* config = (whServerConfig*)cf;
     int ret = 0;
-    whServer server[1];
+    whServerContext server[1];
     int counter = 1;
 
     if (config == NULL) {
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
             .server_id = WH_SERVER_ID,
     }};
     whServerConfig s_conf[1] = {{
-            .comm = cs_conf,
+            .comm_config = cs_conf,
     }};
 
     wh_ServerTask(s_conf);


### PR DESCRIPTION
Updates to the TCP Posix example to now include NVM and crypto objects.  Updated makefile to improve reuseability and clarity.