### PR TITLE
Fix implicit conversion warnings for client and server id values

### DIFF
--- a/posix/tcp/wh_client_tcp/wh_client_tcp.c
+++ b/posix/tcp/wh_client_tcp/wh_client_tcp.c
@@ -26,7 +26,7 @@ enum {
 
 #define WH_SERVER_TCP_IPSTRING "127.0.0.1"
 #define WH_SERVER_TCP_PORT 23456
-#define WH_CLIENT_ID 1234
+#define WH_CLIENT_ID 12
 
 static void* wh_ClientTask(void* cf)
 {

--- a/posix/tcp/wh_server_tcp/wh_server_tcp.c
+++ b/posix/tcp/wh_server_tcp/wh_server_tcp.c
@@ -22,7 +22,7 @@ enum {
 
 #define WH_SERVER_TCP_IPSTRING "127.0.0.1"
 #define WH_SERVER_TCP_PORT 23456
-#define WH_SERVER_ID 5678
+#define WH_SERVER_ID 56
 
 static void* wh_ServerTask(void* cf)
 {


### PR DESCRIPTION
set example client/server ids to 8-bit values