### PR TITLE
Wolfhsm updates

### DIFF
--- a/demo/client/wh_demo_client_all.c
+++ b/demo/client/wh_demo_client_all.c
@@ -1,6 +1,7 @@
 #include "wh_demo_client_all.h"
 #include "wh_demo_client_nvm.h"
 #include "wh_demo_client_keystore.h"
+#include "wh_demo_client_crypto.h"
 #include "wh_demo_client_wctest.h"
 #include "wh_demo_client_wcbench.h"
 

--- a/demo/client/wh_demo_client_all.c
+++ b/demo/client/wh_demo_client_all.c
@@ -1,11 +1,26 @@
 #include "wh_demo_client_all.h"
 #include "wh_demo_client_nvm.h"
 #include "wh_demo_client_keystore.h"
+#include "wh_demo_client_wctest.h"
+#include "wh_demo_client_wcbench.h"
 
 int wh_DemoClient_All(whClientContext* clientContext)
 {
     int rc = 0;
 
+    /* wolfCrypt test and benchmark */
+#ifdef WH_DEMO_WCTEST
+    rc = wh_DemoClient_wcTest(clientContext);
+    if (rc != 0) {
+            return rc;
+    }
+#endif
+#ifdef WH_DEMO_WCBENCH
+    rc = wh_DemoClient_wcBench(clientContext);
+    if (rc != 0) {
+            return rc;
+    }
+#endif
     /* NVM demos */
     rc = wh_DemoClient_Nvm(clientContext);
     if (rc != 0) {

--- a/demo/client/wh_demo_client_crypto.h
+++ b/demo/client/wh_demo_client_crypto.h
@@ -2,18 +2,35 @@
 #define CLIENT_CRYPTO_H_
 #include "wolfhsm/wh_client.h"
 
+#if !defined(NO_RSA)
 int wh_DemoClient_CryptoRsa(whClientContext* clientContext);
 int wh_DemoClient_CryptoRsaImport(whClientContext* clientContext);
+#endif
+
+#ifdef HAVE_CURVE25519
 int wh_DemoClient_CryptoCurve25519(whClientContext* clientContext);
 int wh_DemoClient_CryptoCurve25519Import(whClientContext* clientContext);
+#endif /* HAVE_CURVE25519 */
+
+#if !defined(NO_ECC) && defined(HAVE_ECC)
 int wh_DemoClient_CryptoEcc(whClientContext* clientContext);
 int wh_DemoClient_CryptoEccImport(whClientContext* clientContext);
+#endif /* !NO_ECC && HAVE_ECC */
+
+#if !defined(NO_AES) && defined(HAVE_AES)
 int wh_DemoClient_CryptoAesCbc(whClientContext* clientContext);
 int wh_DemoClient_CryptoAesCbcImport(whClientContext* clientContext);
+#endif /* !NO_AES && HAVE_AES */
+
+#if !defined(NO_AES) && defined(HAVE_AES) && defined(HAVE_AESGCM)
 int wh_DemoClient_CryptoAesGcm(whClientContext* clientContext);
 int wh_DemoClient_CryptoAesGcmImport(whClientContext* clientContext);
+#endif /* !NOAES && HAVE_AES && HAVE_ASEGCM */
+
+#ifdef WOLFSSL_CMAC
 int wh_DemoClient_CryptoCmac(whClientContext* clientContext);
 int wh_DemoClient_CryptoCmacImport(whClientContext* clientContext);
 int wh_DemoClient_CryptoCmacOneshotImport(whClientContext* clientContext);
+#endif /* WOLFSSL_CMAC */
 
 #endif /* CLIENT_CRYPTO_H_ */

--- a/demo/client/wh_demo_client_keystore.c
+++ b/demo/client/wh_demo_client_keystore.c
@@ -120,7 +120,7 @@ int wh_DemoClient_KeystoreCommitKey(whClientContext* clientContext)
 int wh_DemoClient_KeystoreAes(whClientContext* clientContext)
 {
     int      ret;
-    Aes      aes;
+    Aes      aes = {0};
     uint8_t  key[AES_128_KEY_SIZE] = "0123456789abcdef";
     uint8_t  iv[AES_IV_SIZE]       = "1234567890abcdef";
     uint8_t  label[]               = "my secret AES key";

--- a/demo/client/wh_demo_client_keystore.c
+++ b/demo/client/wh_demo_client_keystore.c
@@ -14,7 +14,7 @@ int wh_DemoClient_KeystoreBasic(whClientContext* clientContext)
     int      ret;
     uint8_t  key[AES_128_KEY_SIZE] = "0123456789abcdef";
     uint8_t  label[]               = "my secret key";
-    uint16_t keyId                 = WOLFHSM_KEYID_ERASED;
+    uint16_t keyId                 = WH_KEYID_ERASED;
 
     /* Cache the key in the HSM */
     ret = wh_Client_KeyCache(clientContext, 0, label, sizeof(label), key,
@@ -48,7 +48,7 @@ int wh_DemoClient_KeystoreBasic(whClientContext* clientContext)
 int wh_DemoClient_KeystoreCommitKey(whClientContext* clientContext)
 {
     int      ret;
-    uint16_t keyId                      = WOLFHSM_KEYID_ERASED;
+    uint16_t keyId                      = WH_KEYID_ERASED;
     uint8_t  key[AES_128_KEY_SIZE]      = "0123456789abcdef";
     uint8_t  label[]                    = "my secret key";
     uint8_t  exportKey[sizeof(key)]     = {0};
@@ -127,7 +127,7 @@ int wh_DemoClient_KeystoreAes(whClientContext* clientContext)
     uint8_t  plainText[]           = "This is a test.";
     uint8_t  cipherText[sizeof(plainText)];
     uint8_t  decryptedText[sizeof(plainText)];
-    uint16_t keyId = WOLFHSM_KEYID_ERASED;
+    uint16_t keyId = WH_KEYID_ERASED;
 
     /* Cache the AES key in the HSM */
     ret = wh_Client_KeyCache(clientContext, 0, label, sizeof(label), key,
@@ -156,7 +156,7 @@ int wh_DemoClient_KeystoreAes(whClientContext* clientContext)
      * used at any time, including across server restarts */
 
     /* Initialize AES context to use wolfHSM offload */
-    ret = wc_AesInit(&aes, NULL, WOLFHSM_DEV_ID);
+    ret = wc_AesInit(&aes, NULL, WH_DEV_ID);
     if (ret != 0) {
         printf("Failed to initialize AES: %d\n", ret);
         return ret;
@@ -211,7 +211,7 @@ int wh_DemoClient_KeystoreAes(whClientContext* clientContext)
     /* Though the key is evicted, we can still use it for crypto operations,
      * usage will just require the server to load the key from NVM. The key will
      * be restored in the cache after using it */
-    ret = wc_AesInit(&aes, NULL, WOLFHSM_DEV_ID);
+    ret = wc_AesInit(&aes, NULL, WH_DEV_ID);
     if (ret != 0) {
         printf("Failed to initialize AES: %d\n", ret);
         return ret;

--- a/demo/client/wh_demo_client_nvm.c
+++ b/demo/client/wh_demo_client_nvm.c
@@ -19,8 +19,10 @@ int wh_DemoClient_Nvm(whClientContext* clientContext)
 
     int32_t  rc;
     int32_t  serverRc;
-    uint32_t availSize, reclaimSize;
-    whNvmId  availObjects, reclaimObjects;
+    uint32_t availSize;
+    uint32_t reclaimSize;
+    whNvmId  availObjects;
+    whNvmId  reclaimObjects;
 
     whNvmId   objectIds[] = {1, 2, 3};
     uint8_t   labels[][6] = {"label1", "label2", "label3"};
@@ -48,8 +50,8 @@ int wh_DemoClient_Nvm(whClientContext* clientContext)
     for (int i = 0; i < NUM_OBJECTS; i++) {
         /* Add an object */
         rc = wh_Client_NvmAddObject(clientContext, objectIds[i],
-                                    WOLFHSM_NVM_ACCESS_ANY,
-                                    WOLFHSM_NVM_FLAGS_ANY, sizeof(labels[i]),
+                                    WH_NVM_ACCESS_ANY,
+                                    WH_NVM_FLAGS_ANY, sizeof(labels[i]),
                                     labels[i], dataLen, data[i], &serverRc);
         if (rc != 0 || serverRc != 0) {
             printf("Add Object %d failed with error code: %d, server error "

--- a/demo/client/wh_demo_client_wcbench.c
+++ b/demo/client/wh_demo_client_wcbench.c
@@ -1,0 +1,10 @@
+#include "wolfhsm/wh_client.h"
+
+#include "wolfcrypt/benchmark/benchmark.h"
+
+#include "wh_demo_client_wcbench.h"
+
+int wh_DemoClient_wcBench(whClientContext* clientContext)
+{
+    return benchmark_test(NULL);
+}

--- a/demo/client/wh_demo_client_wcbench.h
+++ b/demo/client/wh_demo_client_wcbench.h
@@ -1,0 +1,7 @@
+#ifndef DEMO_CLIENT_WCBENCH_H_
+#define DEMO_CLIENT_WCBENCH_H_
+#include "wolfhsm/wh_client.h"
+
+int wh_DemoClient_wcBench(whClientContext* clientContext);
+
+#endif /* DEMO_CLIENT_WCBENCH_H_ */

--- a/demo/client/wh_demo_client_wctest.c
+++ b/demo/client/wh_demo_client_wctest.c
@@ -1,0 +1,10 @@
+#include "wolfhsm/wh_client.h"
+
+#include "wolfcrypt/test/test.h"
+
+#include "wh_demo_client_counter.h"
+
+int wh_DemoClient_wcTest(whClientContext* clientContext)
+{
+    return wolfcrypt_test(NULL);
+}

--- a/demo/client/wh_demo_client_wctest.h
+++ b/demo/client/wh_demo_client_wctest.h
@@ -1,0 +1,7 @@
+#ifndef DEMO_CLIENT_WCTEST_H_
+#define DEMO_CLIENT_WCTEST_H_
+#include "wolfhsm/wh_client.h"
+
+int wh_DemoClient_wcTest(whClientContext* clientContext);
+
+#endif /* DEMO_CLIENT_WCTEST_H_ */

--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -55,30 +55,25 @@ LDFLAGS += $(DBGFLAGS)
 #wolfCrypt source files
 SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/src/*.c)
 
+#wolfCrypt test/benchmark source files
+DEF +=   -DWH_DEMO_WCTEST -DWH_DEMO_WCBENCH                 \
+         -DNO_MAIN_DRIVER -DBENCH_EMBEDDED -DNO_FILESYSTEM  \
+         -DWC_USE_DEVID=0x5748534D
+
+SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/test/*.c)
+SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/benchmark/*.c)
+
 #wolfSSL source files
 SRC_C += $(wildcard $(WOLFSSL_DIR)/src/*.c)
 
 # wolfHSM source files
 SRC_C += $(wildcard $(WOLFHSM_DIR)/src/*.c)
-#SRC_C += \
-            $(WOLFHSM_DIR)/src/wh_client.c \
-            $(WOLFHSM_DIR)/src/wh_client_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_client_cryptocb.c \
-            $(WOLFHSM_DIR)/src/wh_utils.c \
-            $(WOLFHSM_DIR)/src/wh_comm.c \
-            $(WOLFHSM_DIR)/src/wh_message_comm.c \
-            $(WOLFHSM_DIR)/src/wh_message_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_message_customcb.c \
-            $(WOLFHSM_DIR)/src/wh_utils.c
 
 # WolfHSM port\HAL code
 SRC_C += $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c
 
 # Demo client code
-SRC_C += $(WOLFHSM_CLIENT_DEMO_DIR)/wh_demo_client_nvm.c \
-         $(WOLFHSM_CLIENT_DEMO_DIR)/wh_demo_client_keystore.c \
-         $(WOLFHSM_CLIENT_DEMO_DIR)/wh_demo_client_crypto.c \
-         $(WOLFHSM_CLIENT_DEMO_DIR)/wh_demo_client_all.c
+SRC_C += $(wildcard $(WOLFHSM_CLIENT_DEMO_DIR)/*.c) 
 
 # APP
 SRC_C += ./src/wh_client_tcp.c

--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -27,7 +27,8 @@ ARCHFLAGS ?=
 # Compiler and linker flags
 ASFLAGS ?= $(ARCHFLAGS)
 CFLAGS_EXTRA ?= -Wno-cpp
-CFLAGS ?= $(ARCHFLAGS) -std=c99 -Wall $(CFLAGS_EXTRA)
+#CFLAGS ?= $(ARCHFLAGS) -std=c99 -Wall $(CFLAGS_EXTRA)
+CFLAGS ?= $(ARCHFLAGS) -Wall $(CFLAGS_EXTRA)
 LDFLAGS ?= $(ARCHFLAGS)
 
 # LD: generate map

--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -27,8 +27,7 @@ ARCHFLAGS ?=
 # Compiler and linker flags
 ASFLAGS ?= $(ARCHFLAGS)
 CFLAGS_EXTRA ?= -Wno-cpp
-#CFLAGS ?= $(ARCHFLAGS) -std=c99 -Wall $(CFLAGS_EXTRA)
-CFLAGS ?= $(ARCHFLAGS) -Wall $(CFLAGS_EXTRA)
+CFLAGS ?= $(ARCHFLAGS) -std=c99 -Wall $(CFLAGS_EXTRA)
 LDFLAGS ?= $(ARCHFLAGS)
 
 # LD: generate map
@@ -59,7 +58,7 @@ SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/src/*.c)
 #wolfCrypt test/benchmark source files
 DEF +=   -DWH_DEMO_WCTEST -DWH_DEMO_WCBENCH                 \
          -DNO_MAIN_DRIVER -DBENCH_EMBEDDED -DNO_FILESYSTEM  \
-         -DWC_USE_DEVID=0x5748534D
+         -D_POSIX_C_SOURCE=200809L -DWC_USE_DEVID=0x5748534D
 
 SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/test/*.c)
 SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/benchmark/*.c)

--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -53,27 +53,14 @@ LDFLAGS += $(DBGFLAGS)
 #SRC_ASM +=
 
 #wolfCrypt source files
-SRC_C += \
-            $(WOLFSSL_DIR)/wolfcrypt/src/wc_port.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/memory.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/misc.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/cryptocb.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/random.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/asn.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/coding.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/wolfmath.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/ecc.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/tfm.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/fe_operations.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/rsa.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/curve25519.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/hash.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/sha256.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/aes.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/cmac.c
+SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/src/*.c)
+
+#wolfSSL source files
+SRC_C += $(wildcard $(WOLFSSL_DIR)/src/*.c)
 
 # wolfHSM source files
-SRC_C += \
+SRC_C += $(wildcard $(WOLFHSM_DIR)/src/*.c)
+#SRC_C += \
             $(WOLFHSM_DIR)/src/wh_client.c \
             $(WOLFHSM_DIR)/src/wh_client_nvm.c \
             $(WOLFHSM_DIR)/src/wh_client_cryptocb.c \

--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -56,8 +56,7 @@ LDFLAGS += $(DBGFLAGS)
 SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/src/*.c)
 
 #wolfCrypt test/benchmark source files
-DEF +=   -DWH_DEMO_WCTEST -DWH_DEMO_WCBENCH                 \
-         -DNO_MAIN_DRIVER -DBENCH_EMBEDDED -DNO_FILESYSTEM  \
+DEF +=   -DNO_MAIN_DRIVER -DBENCH_EMBEDDED -DNO_FILESYSTEM  \
          -D_POSIX_C_SOURCE=200809L -DWC_USE_DEVID=0x5748534D
 
 SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/test/*.c)

--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -33,8 +33,8 @@ LDFLAGS ?= $(ARCHFLAGS)
 # LD: generate map
 #LDFLAGS += -Wl,-Map=$(BUILD_DIR)/$(BIN).map
 
-# Libc for printf
-LIBS = -lc
+# Libc for printf, libm for math
+LIBS = -lc -lm
 
 # Optimization level and place functions / data into separate sections to allow dead code removal
 CFLAGS += -O0 -ffunction-sections -fdata-sections

--- a/posix/tcp/wh_client_tcp/Makefile
+++ b/posix/tcp/wh_client_tcp/Makefile
@@ -81,7 +81,8 @@ SRC_C += \
             $(WOLFHSM_DIR)/src/wh_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_message_customcb.c
+            $(WOLFHSM_DIR)/src/wh_message_customcb.c \
+            $(WOLFHSM_DIR)/src/wh_utils.c
 
 # WolfHSM port\HAL code
 SRC_C += $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c

--- a/posix/tcp/wh_client_tcp/user_settings.h
+++ b/posix/tcp/wh_client_tcp/user_settings.h
@@ -1,4 +1,5 @@
-#ifndef USER_SETTINGS_H
+#ifndef USER_SETTINGS_H_
+#define USER_SETTINGS_H_
 
 /* Client wolfSSL settings */
 

--- a/posix/tcp/wh_client_tcp/user_settings.h
+++ b/posix/tcp/wh_client_tcp/user_settings.h
@@ -22,6 +22,9 @@
 
 /* Include to ensure clock_gettime is declared for benchmark.c */
 #include <time.h>
+/* Include to support strcasecmp with POSIX build */
+#include <strings.h>
+
 
 #if 0
 

--- a/posix/tcp/wh_client_tcp/user_settings.h
+++ b/posix/tcp/wh_client_tcp/user_settings.h
@@ -8,10 +8,19 @@
 
 /* Optional if debugging cryptocb's */
 #define DEBUG_CRYPTOCB
+#define DEBUG_CRYPTOCB_VERBOSE
 
-/* Temporarily set this to key export function without keygen */
-#define OPENSSL_EXTRA
+/* Temporarily set this to key export function  */
+#define WOLFSSL_KEY_GEN
+#define HAVE_CURVE25519
+#define HAVE_ECC
+#define HAVE_AES
+#define HAVE_AESGCM
+#define WOLFSSL_AES_DIRECT
+#define WOLFSSL_CMAC
 
+/* Include to ensure clock_gettime is declared for benchmark.c */
+#include <time.h>
 
 #if 0
 

--- a/posix/tcp/wh_client_tcp/user_settings.h
+++ b/posix/tcp/wh_client_tcp/user_settings.h
@@ -6,6 +6,9 @@
 #define WOLF_CRYPTO_CB
 #define HAVE_ANONYMOUS_INLINE_AGGREGATES 1
 
+/* Optional if debugging cryptocb's */
+#define DEBUG_CRYPTOCB
+
 /* Temporarily set this to key export function without keygen */
 #define OPENSSL_EXTRA
 

--- a/posix/tcp/wh_client_tcp/user_settings.h
+++ b/posix/tcp/wh_client_tcp/user_settings.h
@@ -2,20 +2,29 @@
 
 /* Client wolfSSL settings */
 
+/* wolfHSM Required */
+#define WOLF_CRYPTO_CB
+#define HAVE_ANONYMOUS_INLINE_AGGREGATES 1
+
+/* Temporarily set this to key export function without keygen */
+#define OPENSSL_EXTRA
+
+
+#if 0
+
+/* Math library selection.  */
+#define USE_FAST_MATH
+
 /* Common configuration */
 #define WOLFCRYPT_ONLY
 #define WOLFSSL_KEY_GEN
 //#define BIG_ENDIAN_ORDER
-#define WOLF_CRYPTO_CB
 //#define WOLFSSL_KEY_GEN
 #define SINGLE_THREADED
 #define WC_NO_ASYNC_THREADING
 #define WOLFSSL_USE_ALIGN
 #define HAVE_WC_INTROSPECTION
 #define WOLFSSL_IGNORE_FILE_WARN
-
-#define HAVE_ANONYMOUS_INLINE_AGGREGATES 1
-
 #define WOLFSSL_NO_MALLOC
 
 /* Hardening options */
@@ -41,7 +50,6 @@
 #define NO_OLD_MD5_NAME
 
 /* RSA Options */
-//#define NO_RSA
 #define HAVE_RSA
 #define WC_RSA_PSS
 #define WOLFSSL_PSS_LONG_SALT
@@ -107,8 +115,8 @@
 /* Curve25519 Options */
 #define HAVE_CURVE25519
 
-/* Math library selection.  Update makefile list if changed */
-#define USE_FAST_MATH
+#endif
+
 
 
 #endif

--- a/posix/tcp/wh_client_tcp/wh_client_tcp.c
+++ b/posix/tcp/wh_client_tcp/wh_client_tcp.c
@@ -16,7 +16,7 @@
 #include "wh_demo_client_all.h"
 
 /** Local declarations */
-static void* wh_ClientTask(void* cf);
+static int wh_ClientTask(void* cf);
 
 
 enum {
@@ -30,7 +30,7 @@ enum {
 #define WH_SERVER_TCP_PORT 23456
 #define WH_CLIENT_ID 12
 
-static void* wh_ClientTask(void* cf)
+static int wh_ClientTask(void* cf)
 {
     whClientConfig* config = (whClientConfig*)cf;
     int ret = 0;
@@ -44,7 +44,7 @@ static void* wh_ClientTask(void* cf)
     uint16_t rx_resp_len = 0;
 
     if (config == NULL) {
-        return NULL;
+        return -1;
     }
 
     ret = wh_Client_Init(client, config);
@@ -52,7 +52,7 @@ static void* wh_ClientTask(void* cf)
 
     if (ret != 0) {
         perror("Init error:");
-        return NULL;
+        return -1;
     }
     for(counter = 0; counter < REPEAT_COUNT; counter++)
     {
@@ -96,10 +96,10 @@ static void* wh_ClientTask(void* cf)
     }
 
 
-    wh_Client_CommClose(client);
-    ret = wh_Client_Cleanup(client);
+    (void)wh_Client_CommClose(client);
+    (void)wh_Client_Cleanup(client);
     printf("Client disconnected\n");
-    return NULL;
+    return ret;
 }
 
 int main(int argc, char** argv)
@@ -124,7 +124,5 @@ int main(int argc, char** argv)
             .comm = cc_conf,
     }};
 
-    wh_ClientTask(c_conf);
-
-    return 0;
+    return wh_ClientTask(c_conf);
 }

--- a/posix/tcp/wh_client_tcp/wolfhsm_cfg.h
+++ b/posix/tcp/wh_client_tcp/wolfhsm_cfg.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm_cfg.h
+ *
+ * wolfHSM compile-time options.  Override here for your application
+ */
+
+#ifndef WOLFHSM_CFG_H_
+#define WOLFHSM_CFG_H_
+
+
+/** wolfHSM settings.  Simple overrides to show they work */
+/* #define WOLFHSM_CFG_NO_CRYPTO */
+#define WOLFHSM_CFG_SHE_EXTENSION
+
+#define WOLFHSM_CFG_COMM_DATA_LEN 1280
+
+#endif /* WOLFHSM_CFG_H_ */

--- a/posix/tcp/wh_client_tcp/wolfhsm_cfg.h
+++ b/posix/tcp/wh_client_tcp/wolfhsm_cfg.h
@@ -26,7 +26,7 @@
 #define WOLFHSM_CFG_H_
 
 
-/** wolfHSM settings.  Simple overrides to show they work */
+/** wolfHSM settings */
 /* #define WOLFHSM_CFG_NO_CRYPTO */
 #define WOLFHSM_CFG_SHE_EXTENSION
 

--- a/posix/tcp/wh_server_tcp/Makefile
+++ b/posix/tcp/wh_server_tcp/Makefile
@@ -50,8 +50,17 @@ LDFLAGS += $(DBGFLAGS)
 # Assembly source files
 SRC_ASM += 
 
+#wolfCrypt source files
+SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/src/*.c)
+
+#wolfSSL source files
+SRC_C += $(wildcard $(WOLFSSL_DIR)/src/*.c)
+
+# wolfHSM source files
+SRC_C += $(wildcard $(WOLFHSM_DIR)/src/*.c)
+
 # wolfCrypt source files
-SRC_C += \
+#SRC_C += \
             $(WOLFSSL_DIR)/wolfcrypt/src/wc_port.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/memory.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/misc.c \
@@ -71,7 +80,7 @@ SRC_C += \
             $(WOLFSSL_DIR)/wolfcrypt/src/cmac.c
 
 # WolfHSM source files
-SRC_C += \
+#SRC_C += \
             $(WOLFHSM_DIR)/src/wh_server.c \
             $(WOLFHSM_DIR)/src/wh_server_customcb.c \
             $(WOLFHSM_DIR)/src/wh_server_dma.c \
@@ -85,14 +94,13 @@ SRC_C += \
             $(WOLFHSM_DIR)/src/wh_message_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_nvm.c \
             $(WOLFHSM_DIR)/src/wh_message_customcb.c \
-            $(WOLFHSM_DIR)/src/wh_utils.c
-
-# WolfHSM port\HAL code
-SRC_C += \
+            $(WOLFHSM_DIR)/src/wh_utils.c \
             $(WOLFHSM_DIR)/src/wh_nvm_flash.c \
             $(WOLFHSM_DIR)/src/wh_flash_unit.c \
-            $(WOLFHSM_DIR)/src/wh_flash_ramsim.c \
-            $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c
+            $(WOLFHSM_DIR)/src/wh_flash_ramsim.c 
+
+# WolfHSM port\HAL code
+SRC_C +=    $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c
 
 # APP
 SRC_C += ./src/wh_server_tcp.c 

--- a/posix/tcp/wh_server_tcp/Makefile
+++ b/posix/tcp/wh_server_tcp/Makefile
@@ -84,7 +84,8 @@ SRC_C += \
             $(WOLFHSM_DIR)/src/wh_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_comm.c \
             $(WOLFHSM_DIR)/src/wh_message_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_message_customcb.c
+            $(WOLFHSM_DIR)/src/wh_message_customcb.c \
+            $(WOLFHSM_DIR)/src/wh_utils.c
 
 # WolfHSM port\HAL code
 SRC_C += \

--- a/posix/tcp/wh_server_tcp/Makefile
+++ b/posix/tcp/wh_server_tcp/Makefile
@@ -31,8 +31,8 @@ LDFLAGS ?= $(ARCHFLAGS)
 # LD: generate map
 #LDFLAGS += -Wl,-Map=$(BUILD_DIR)/$(BIN).map
 
-# Libc for printf
-LIBS = -lc
+# Libc for printf, libm for math
+LIBS = -lc -lm
 
 # Optimization level and place functions / data into separate sections to allow dead code removal 
 CFLAGS += -O0 -ffunction-sections -fdata-sections 

--- a/posix/tcp/wh_server_tcp/Makefile
+++ b/posix/tcp/wh_server_tcp/Makefile
@@ -53,9 +53,6 @@ SRC_ASM +=
 #wolfCrypt source files
 SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/src/*.c)
 
-#wolfSSL source files
-SRC_C += $(wildcard $(WOLFSSL_DIR)/src/*.c)
-
 # wolfHSM source files
 SRC_C += $(wildcard $(WOLFHSM_DIR)/src/*.c)
 

--- a/posix/tcp/wh_server_tcp/Makefile
+++ b/posix/tcp/wh_server_tcp/Makefile
@@ -59,50 +59,10 @@ SRC_C += $(wildcard $(WOLFSSL_DIR)/src/*.c)
 # wolfHSM source files
 SRC_C += $(wildcard $(WOLFHSM_DIR)/src/*.c)
 
-# wolfCrypt source files
-#SRC_C += \
-            $(WOLFSSL_DIR)/wolfcrypt/src/wc_port.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/memory.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/misc.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/cryptocb.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/random.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/asn.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/coding.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/wolfmath.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/ecc.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/tfm.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/fe_operations.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/rsa.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/curve25519.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/hash.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/sha256.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/aes.c \
-            $(WOLFSSL_DIR)/wolfcrypt/src/cmac.c
-
-# WolfHSM source files
-#SRC_C += \
-            $(WOLFHSM_DIR)/src/wh_server.c \
-            $(WOLFHSM_DIR)/src/wh_server_customcb.c \
-            $(WOLFHSM_DIR)/src/wh_server_dma.c \
-            $(WOLFHSM_DIR)/src/wh_server_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_server_crypto.c \
-            $(WOLFHSM_DIR)/src/wh_server_keystore.c \
-            $(WOLFHSM_DIR)/src/wh_server_counter.c \
-            $(WOLFHSM_DIR)/src/wh_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_utils.c \
-            $(WOLFHSM_DIR)/src/wh_comm.c \
-            $(WOLFHSM_DIR)/src/wh_message_comm.c \
-            $(WOLFHSM_DIR)/src/wh_message_nvm.c \
-            $(WOLFHSM_DIR)/src/wh_message_customcb.c \
-            $(WOLFHSM_DIR)/src/wh_utils.c \
-            $(WOLFHSM_DIR)/src/wh_nvm_flash.c \
-            $(WOLFHSM_DIR)/src/wh_flash_unit.c \
-            $(WOLFHSM_DIR)/src/wh_flash_ramsim.c 
-
 # WolfHSM port\HAL code
 SRC_C +=    $(WOLFHSM_DIR)/port/posix/posix_transport_tcp.c
 
-# APP
+# Server App
 SRC_C += ./src/wh_server_tcp.c 
 
 

--- a/posix/tcp/wh_server_tcp/user_settings.h
+++ b/posix/tcp/wh_server_tcp/user_settings.h
@@ -2,27 +2,14 @@
 #define USER_SETTINGS_H
 /* Server wolfSSL settings */
 
-/* wolfHSM Required */
-#define WOLF_CRYPTO_CB
 #define HAVE_ANONYMOUS_INLINE_AGGREGATES 1
 
-/* Key gen is currently required on the server */
-#define WOLFSSL_KEY_GEN
-#define HAVE_CURVE25519
-#define HAVE_ECC
-#define HAVE_AES
-#define HAVE_AESGCM
-#define HAVE_AES_ECB
-#define WOLFSSL_AES_DIRECT
-#define WOLFSSL_CMAC
-
-
-#if 0
 /* Common configuration */
 #define WOLFCRYPT_ONLY
 /* #define BIG_ENDIAN_ORDER */
-
-
+#define WOLF_CRYPTO_CB
+/* Key gen is currently required on the server */
+#define WOLFSSL_KEY_GEN
 #define SINGLE_THREADED
 #define WC_NO_ASYNC_THREADING
 #define WOLFSSL_USE_ALIGN
@@ -116,7 +103,7 @@
 
 #define USE_FAST_MATH
 
-#endif
+
 
 #endif  /*define USER_SETTINGS_H */
 

--- a/posix/tcp/wh_server_tcp/user_settings.h
+++ b/posix/tcp/wh_server_tcp/user_settings.h
@@ -16,9 +16,6 @@
 #define WOLFSSL_AES_DIRECT
 #define WOLFSSL_CMAC
 
-/* Include to ensure clock_gettime is declared for benchmark.c */
-#include <time.h>
-
 
 #if 0
 /* Common configuration */

--- a/posix/tcp/wh_server_tcp/user_settings.h
+++ b/posix/tcp/wh_server_tcp/user_settings.h
@@ -103,6 +103,8 @@
 
 #define USE_FAST_MATH
 
+/* Random inclusions appropriate for POSIX platforms */
+#define HAVE_STRINGS_H
 
 
 #endif  /*define USER_SETTINGS_H */

--- a/posix/tcp/wh_server_tcp/user_settings.h
+++ b/posix/tcp/wh_server_tcp/user_settings.h
@@ -8,6 +8,17 @@
 
 /* Key gen is currently required on the server */
 #define WOLFSSL_KEY_GEN
+#define HAVE_CURVE25519
+#define HAVE_ECC
+#define HAVE_AES
+#define HAVE_AESGCM
+#define HAVE_AES_ECB
+#define WOLFSSL_AES_DIRECT
+#define WOLFSSL_CMAC
+
+/* Include to ensure clock_gettime is declared for benchmark.c */
+#include <time.h>
+
 
 #if 0
 /* Common configuration */

--- a/posix/tcp/wh_server_tcp/user_settings.h
+++ b/posix/tcp/wh_server_tcp/user_settings.h
@@ -2,14 +2,19 @@
 #define USER_SETTINGS_H
 /* Server wolfSSL settings */
 
-/* Common configuration */
-#define WOLFCRYPT_ONLY
-/* #define BIG_ENDIAN_ORDER */
+/* wolfHSM Required */
 #define WOLF_CRYPTO_CB
 #define HAVE_ANONYMOUS_INLINE_AGGREGATES 1
 
 /* Key gen is currently required on the server */
 #define WOLFSSL_KEY_GEN
+
+#if 0
+/* Common configuration */
+#define WOLFCRYPT_ONLY
+/* #define BIG_ENDIAN_ORDER */
+
+
 #define SINGLE_THREADED
 #define WC_NO_ASYNC_THREADING
 #define WOLFSSL_USE_ALIGN
@@ -103,7 +108,7 @@
 
 #define USE_FAST_MATH
 
-
+#endif
 
 #endif  /*define USER_SETTINGS_H */
 

--- a/posix/tcp/wh_server_tcp/user_settings.h
+++ b/posix/tcp/wh_server_tcp/user_settings.h
@@ -6,6 +6,8 @@
 #define WOLFCRYPT_ONLY
 /* #define BIG_ENDIAN_ORDER */
 #define WOLF_CRYPTO_CB
+#define HAVE_ANONYMOUS_INLINE_AGGREGATES 1
+
 /* Key gen is currently required on the server */
 #define WOLFSSL_KEY_GEN
 #define SINGLE_THREADED

--- a/posix/tcp/wh_server_tcp/wh_server_tcp.c
+++ b/posix/tcp/wh_server_tcp/wh_server_tcp.c
@@ -17,7 +17,7 @@
 #include "port/posix/posix_transport_tcp.h"
 
 /** Local declarations */
-static void* wh_ServerTask(void* cf);
+static int wh_ServerTask(void* cf);
 
 enum {
 	ONE_MS = 1000,
@@ -28,7 +28,7 @@ enum {
 #define WH_SERVER_TCP_PORT 23456
 #define WH_SERVER_ID 56
 
-static void* wh_ServerTask(void* cf)
+static int wh_ServerTask(void* cf)
 {
     whServerContext server[1];
     whServerConfig* config = (whServerConfig*)cf;
@@ -37,7 +37,7 @@ static void* wh_ServerTask(void* cf)
     whCommConnected am_connected = WH_COMM_CONNECTED;
 
     if (config == NULL) {
-        return NULL;
+        return -1;
     }
 
     ret = wh_Server_Init(server, config);
@@ -61,10 +61,14 @@ static void* wh_ServerTask(void* cf)
             }
             wh_Server_GetConnected(server, &am_connected);
         }
-        ret = wh_Server_Cleanup(server);
+        if (ret != 0) {
+            (void)wh_Server_Cleanup(server);
+        } else {
+            ret = wh_Server_Cleanup(server);
+        }
         printf("Server disconnected\n");
     }
-    return NULL;
+    return ret;
 }
 
 int main(int argc, char** argv)
@@ -140,7 +144,7 @@ int main(int argc, char** argv)
         return rc;
     }
 
-    wh_ServerTask(s_conf);
+    rc = wh_ServerTask(s_conf);
 
-    return 0;
+    return rc;
 }

--- a/posix/tcp/wh_server_tcp/wh_server_tcp.c
+++ b/posix/tcp/wh_server_tcp/wh_server_tcp.c
@@ -129,6 +129,10 @@ int main(int argc, char** argv)
         printf("Failed to initialize NVM: %d\n", rc);
         return rc;
     }
+    /* Initialize crypto library and hardware */
+    wolfCrypt_Init();
+
+    wc_InitRng_ex(crypto->rng, NULL, crypto->devId);
 
     rc = wc_InitRng_ex(crypto->rng, NULL, crypto->devId);
     if (rc != 0) {

--- a/posix/tcp/wh_server_tcp/wolfhsm_cfg.h
+++ b/posix/tcp/wh_server_tcp/wolfhsm_cfg.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm_cfg.h
+ *
+ * wolfHSM compile-time options.  Override here for your application
+ */
+
+#ifndef WOLFHSM_CFG_H_
+#define WOLFHSM_CFG_H_
+
+
+/** wolfHSM settings.  Simple overrides to show they work */
+/* #define WOLFHSM_CFG_NO_CRYPTO */
+#define WOLFHSM_CFG_SHE_EXTENSION
+
+#define WOLFHSM_CFG_COMM_DATA_LEN 1280
+
+#define WOLFHSM_CFG_NVM_OBJECT_COUNT 32
+#define WOLFHSM_CFG_SERVER_KEYCACHE_COUNT 10
+#define WOLFHSM_CFG_SERVER_KEYCACHE_SIZE 1024
+#define WOLFHSM_CFG_SERVER_DMAADDR_COUNT 8
+#define WOLFHSM_CFG_SERVER_CUSTOMCB_COUNT 8
+
+#endif /* WOLFHSM_CFG_H_ */


### PR DESCRIPTION
Pulls in some of the updates from #12 (which are needed), but with the following changes:
- omits the user_settings.h modifications
- omits inclusion of wolfSSL source code on the server side. 
- keeps test/bench demos, but turns them off by default, since tests don't pass 

NOTE: This contains a hack in [85d2622](https://github.com/wolfSSL/wolfHSM-examples/pull/14/commits/85d2622fa51280697531b5471a3faaf888d39b63) that zeros out the AES context to get it to work. Instead, this needs to be done in wh_Client_SetKeyIdAes() so that garbage doesn't fail the length check in wolfcrypt AES
 
Stopgap so we can get the changes in. 